### PR TITLE
Don't retain unreferenced servers

### DIFF
--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -39,7 +39,8 @@ open class Server {
                 tlsConfig = TLS.Configuration(certificate: cert)
             }
         socket = try Socket.tcpListening(port: port, address: address)
-        queue.async {
+        queue.async { [weak self] in
+            guard let self = self else {return}
             while let client = try? self.socket.accept() {
                 self.handleConnection(client)
                 client.close()

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -40,7 +40,7 @@ open class Server {
             }
         socket = try Socket.tcpListening(port: port, address: address)
         queue.async { [weak self] in
-            guard let self = self else {return}
+            guard let `self` = self else { return }
             while let client = try? self.socket.accept() {
                 self.handleConnection(client)
                 client.close()


### PR DESCRIPTION
Don't retain unreferenced servers. Prior to this PR, server instances would self-retain until they were stopped via `.stop()`. 

Closes #8