### PR TITLE
Replace existing route when adding new route has same path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,21 @@ matrix:
       script: env LD_LIBRARY_PATH='/usr/local/lib:/usr/local/opt/libressl/lib:$LD_LIBRARY_PATH' swift test
       
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode11.2
       dist: trusty
       sudo: required
       env: ACTION=test  PLATFORM=Mac     DESTINATION='platform=OS X'
       script: set -o pipefail && xcodebuild -project HttpSwift.xcodeproj -scheme HttpSwift -destination "$DESTINATION" $ACTION | xcpretty
 
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode11.2
       dist: trusty
       sudo: required
       env: ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 6S'
       script: set -o pipefail && xcodebuild -project HttpSwift.xcodeproj -scheme HttpSwift -destination "$DESTINATION" $ACTION | xcpretty
 
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode11.2
       dist: trusty
       sudo: required
       env: ACTION=test  PLATFORM=tvOS    DESTINATION='platform=tvOS Simulator,name=Apple TV'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       osx_image: xcode11.2
       dist: trusty
       sudo: required
-      env: ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 6S'
+      env: ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 11'
       script: set -o pipefail && xcodebuild -project HttpSwift.xcodeproj -scheme HttpSwift -destination "$DESTINATION" $ACTION | xcpretty
 
     - os: osx

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -31,7 +31,7 @@ open class Router {
     
     open func add(_ route: inout Route) {
         let path = prefix.appendingPathComponent(route.path)
-        routes.removeAll{ $0.path == path }
+        routes.removeAll { $0.path == path }
         
         let middlewares = self.middlewares + route.middlewares
         route = Route(method: route.method, path: path, handler: route.handler)

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -31,7 +31,7 @@ open class Router {
     
     open func add(_ route: inout Route) {
         let path = prefix.appendingPathComponent(route.path)
-        routes.removeAll { $0.path == path }
+        removeRouteHasPath(path)
         
         let middlewares = self.middlewares + route.middlewares
         route = Route(method: route.method, path: path, handler: route.handler)
@@ -46,5 +46,13 @@ open class Router {
         code()
         self.middlewares.removeLast(middlewares.count)
         self.prefix = prev
+    }
+    
+    private func removeRouteHasPath(_ path: String) {
+        #if swift(>=4.2)
+        routes.removeAll { $0.path == path }
+        #else
+        routes = routes.filter { $0.path != path}
+        #endif
     }
 }

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -31,7 +31,7 @@ open class Router {
     
     open func add(_ route: inout Route) {
         let path = prefix.appendingPathComponent(route.path)
-        removeRouteHasPath(path)
+        routes.removeAll{ $0.path == path }
         
         let middlewares = self.middlewares + route.middlewares
         route = Route(method: route.method, path: path, handler: route.handler)
@@ -46,9 +46,5 @@ open class Router {
         code()
         self.middlewares.removeLast(middlewares.count)
         self.prefix = prev
-    }
-    
-    private func removeRouteHasPath(_ path: String) {
-        routes.removeAll(where: { $0.path == path })
     }
 }

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -30,8 +30,11 @@ open class Router {
     open var middlewares: [MiddlewareHandler] = []
     
     open func add(_ route: inout Route) {
+        let path = prefix.appendingPathComponent(route.path)
+        removeRouteHasPath(path)
+        
         let middlewares = self.middlewares + route.middlewares
-        route = Route(method: route.method, path: prefix.appendingPathComponent(route.path), handler: route.handler)
+        route = Route(method: route.method, path: path, handler: route.handler)
         route.middlewares = middlewares
         routes.append(route)
     }
@@ -43,5 +46,9 @@ open class Router {
         code()
         self.middlewares.removeLast(middlewares.count)
         self.prefix = prev
+    }
+    
+    private func removeRouteHasPath(_ path: String) {
+        routes.removeAll(where: { $0.path == path })
     }
 }

--- a/Tests/HttpSwiftTests/HttpSwiftTests.swift
+++ b/Tests/HttpSwiftTests/HttpSwiftTests.swift
@@ -286,6 +286,35 @@ class HttpSwiftTests: XCTestCase {
         XCTAssertEqual(try? socket.readLine(), "Securely connected")
     }
     
+    func testReplaceExistingRoute() {
+        let firstResponseString = "FirstResponseString"
+        let secondResponseString = "FirstResponseString"
+        
+        server.get("/hello/{id}/{name}/next/{part}") { request in
+            return .ok(firstResponseString)
+        }
+        
+        let ex1 = expectation(description: "testResponseForOldRoute")
+        client.request("/hello/23/hi/next/second", method: .get)
+            .responseString { r in
+                XCTAssertEqual(r.value, firstResponseString)
+                ex1.fulfill()
+        }
+        
+        server.get("/hello/{id}/{name}/next/{part}") { request in
+            return .ok(secondResponseString)
+        }
+        
+        let ex2 = expectation(description: "testResponseForNewRoute")
+        client.request("/hello/23/hi/next/second", method: .get)
+            .responseString { r in
+                XCTAssertEqual(r.value, secondResponseString)
+                ex2.fulfill()
+        }
+        
+        waitForExpectations()
+    }
+    
     static var allTests = [
         ("testRoute", testRoute),
         ("testRequestAndResponse", testRequestAndResponse),

--- a/Tests/HttpSwiftTests/HttpSwiftTests.swift
+++ b/Tests/HttpSwiftTests/HttpSwiftTests.swift
@@ -288,7 +288,7 @@ class HttpSwiftTests: XCTestCase {
     
     func testReplaceExistingRoute() {
         let firstResponseString = "FirstResponseString"
-        let secondResponseString = "FirstResponseString"
+        let secondResponseString = "SecondResponseString"
         
         server.get("/hello/{id}/{name}/next/{part}") { request in
             return .ok(firstResponseString)
@@ -300,6 +300,8 @@ class HttpSwiftTests: XCTestCase {
                 XCTAssertEqual(r.value, firstResponseString)
                 ex1.fulfill()
         }
+        
+        waitForExpectations()
         
         server.get("/hello/{id}/{name}/next/{part}") { request in
             return .ok(secondResponseString)


### PR DESCRIPTION
I found a problem when I try to replace a route with new route has same path. Router just adds new router instead of replacing existing route.

In this PR, I added code to replace all route has same path with new route 