### PR TITLE
Fix: Only replace route has same path and method

### DIFF
--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -31,7 +31,7 @@ open class Router {
     
     open func add(_ route: inout Route) {
         let path = prefix.appendingPathComponent(route.path)
-        removeRouteHasPath(path)
+        removeRouteHasPath(path, method: route.method)
         
         let middlewares = self.middlewares + route.middlewares
         route = Route(method: route.method, path: path, handler: route.handler)
@@ -48,11 +48,11 @@ open class Router {
         self.prefix = prev
     }
     
-    private func removeRouteHasPath(_ path: String) {
+    private func removeRouteHasPath(_ path: String, method: String) {
         #if swift(>=4.2)
-        routes.removeAll { $0.path == path }
+        routes.removeAll { $0.path == path && $0.method == method }
         #else
-        routes = routes.filter { $0.path != path}
+        routes = routes.filter { !($0.path == path && $0.method == method) }
         #endif
     }
 }

--- a/Tests/HttpSwiftTests/HttpSwiftTests.swift
+++ b/Tests/HttpSwiftTests/HttpSwiftTests.swift
@@ -290,30 +290,54 @@ class HttpSwiftTests: XCTestCase {
         let firstResponseString = "FirstResponseString"
         let secondResponseString = "SecondResponseString"
         
+        // GET Request
         server.get("/hello/{id}/{name}/next/{part}") { request in
             return .ok(firstResponseString)
         }
         
-        let ex1 = expectation(description: "testResponseForOldRoute")
+        // GET Request
+        server.post("/hello/{id}/{name}/next/{part}") { request in
+            return .ok(firstResponseString)
+        }
+        
+        // Test for GET request
+        let ex1 = expectation(description: "testResponseForOldGETRoute")
         client.request("/hello/23/hi/next/second", method: .get)
             .responseString { r in
                 XCTAssertEqual(r.value, firstResponseString)
                 ex1.fulfill()
         }
-        
         waitForExpectations()
         
+        // Test for POST Reqquest
+        let ex2 = expectation(description: "testResponseForPOSTRoute")
+        client.request("/hello/23/hi/next/second", method: .post)
+            .responseString { r in
+                XCTAssertEqual(r.value, firstResponseString)
+                ex2.fulfill()
+        }
+        waitForExpectations()
+        
+        // Replace old GET request
         server.get("/hello/{id}/{name}/next/{part}") { request in
             return .ok(secondResponseString)
         }
         
-        let ex2 = expectation(description: "testResponseForNewRoute")
+        let ex3 = expectation(description: "testResponseForNewGETRoute")
         client.request("/hello/23/hi/next/second", method: .get)
             .responseString { r in
                 XCTAssertEqual(r.value, secondResponseString)
-                ex2.fulfill()
+                ex3.fulfill()
         }
+        waitForExpectations()
         
+        // Test for POST Reqquest
+        let ex4 = expectation(description: "testResponseForPOSTRoute")
+        client.request("/hello/23/hi/next/second", method: .post)
+            .responseString { r in
+                XCTAssertEqual(r.value, firstResponseString)
+                ex4.fulfill()
+        }
         waitForExpectations()
     }
     


### PR DESCRIPTION
@OrkhanAlikhanov Sorry, my code is not good. We only need remove existing route has same **method and path** instead of only **PATH**

I updated code and tests